### PR TITLE
fix(context): make startup validation testable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/bot.js",
     "dev": "node --watch src/bot.js",
+    "test:context": "node --test scripts/test-context.js",
     "test:voice": "node scripts/test-voice-pipeline.js"
   },
   "keywords": [

--- a/scripts/test-context.js
+++ b/scripts/test-context.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { after, before, test } = require('node:test');
+
+const contextPath = path.resolve(__dirname, '../src/context.js');
+const botPath = path.resolve(__dirname, '../src/bot.js');
+const context = require(contextPath);
+let fixtureRoot;
+let validRepoPath;
+
+function createValidRepo(target) {
+  for (const artifact of context.REQUIRED_ARTIFACTS) {
+    const artifactPath = path.join(target, artifact);
+    fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+    fs.writeFileSync(artifactPath, `fixture for ${artifact}\n`);
+  }
+}
+
+before(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'demerzel-context-'));
+  validRepoPath = path.join(fixtureRoot, 'valid');
+  createValidRepo(validRepoPath);
+});
+
+after(() => {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+test('importing context has no process-level validation side effect', () => {
+  const missingRepo = path.join(fixtureRoot, 'missing-import-target');
+  const result = spawnSync(
+    process.execPath,
+    ['-e', `require(${JSON.stringify(contextPath)}); process.stdout.write('imported')`],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, DEMERZEL_REPO_PATH: missingRepo },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, 'imported');
+});
+
+test('accepts a repo containing every required governance artifact', () => {
+  assert.equal(typeof context.validateDemerzelPath, 'function');
+  assert.deepEqual(context.validateDemerzelPath(validRepoPath), {
+    ok: true,
+    resolvedPath: path.resolve(validRepoPath),
+    missingArtifacts: [],
+    message: `[demerzel-bot] Demerzel repo validated at: ${path.resolve(validRepoPath)}`,
+  });
+});
+
+test('rejects a missing Demerzel repo with an actionable message', () => {
+  const missingRepo = path.join(fixtureRoot, 'missing-repo');
+  const result = context.validateDemerzelPath(missingRepo);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.resolvedPath, path.resolve(missingRepo));
+  assert.deepEqual(result.missingArtifacts, []);
+  assert.match(result.message, /Demerzel repo not found/);
+  assert.match(result.message, /DEMERZEL_REPO_PATH/);
+});
+
+test('bot startup fails closed before loading the runtime', () => {
+  const missingRepo = path.join(fixtureRoot, 'missing-startup-repo');
+  const result = spawnSync(process.execPath, [botPath], {
+    encoding: 'utf8',
+    env: { ...process.env, DEMERZEL_REPO_PATH: missingRepo },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Demerzel repo not found/);
+  assert.match(result.stderr, /DEMERZEL_REPO_PATH/);
+  assert.doesNotMatch(result.stderr, /MODULE_NOT_FOUND/);
+});
+
+for (const missingArtifact of [
+  'constitutions/default.constitution.md',
+  'constitutions/asimov.constitution.md',
+  'constitutions/demerzel-mandate.md',
+]) {
+  test(`rejects a repo missing ${missingArtifact}`, () => {
+    const incompleteRepo = path.join(
+      fixtureRoot,
+      `missing-${path.basename(missingArtifact, path.extname(missingArtifact))}`,
+    );
+
+    if (!context.REQUIRED_ARTIFACTS) {
+      assert.fail('context.js must export REQUIRED_ARTIFACTS');
+    }
+    createValidRepo(incompleteRepo);
+    fs.rmSync(path.join(incompleteRepo, missingArtifact));
+
+    const result = context.validateDemerzelPath(incompleteRepo);
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missingArtifacts, [missingArtifact]);
+    assert.match(result.message, new RegExp(missingArtifact.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(result.message, /git pull/);
+  });
+}

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,4 +1,21 @@
 require('dotenv').config();
+const {
+  validateDemerzelPath,
+  buildDemerzelSystemPrompt,
+  buildSeldonSystemPrompt,
+  buildGASystemPrompt,
+  buildBSPrompt,
+  getMusicTools,
+  getGovernanceTools,
+} = require('./context');
+
+const contextValidation = validateDemerzelPath();
+if (!contextValidation.ok) {
+  console.error(contextValidation.message);
+  process.exit(1);
+}
+console.log(contextValidation.message);
+
 const { Client, GatewayIntentBits, Partials, EmbedBuilder, ChannelType } = require('discord.js');
 const voice = require('./voice');
 const fs = require('fs');
@@ -19,7 +36,6 @@ if (fs.existsSync(LOCK_FILE)) {
 fs.writeFileSync(LOCK_FILE, String(process.pid));
 const Anthropic = require('@anthropic-ai/sdk').default;
 const OpenAI = require('openai').default;
-const { buildDemerzelSystemPrompt, buildSeldonSystemPrompt, buildGASystemPrompt, buildBSPrompt, getMusicTools, getGovernanceTools } = require('./context');
 const { renderFretboard, renderChordProgression, tryRenderFromText } = require('./vexRenderer');
 const { tryLocal } = require('./llm-router');
 const USE_LOCAL_FIRST = process.env.DEMERZEL_LOCAL_FIRST !== '0'; // default ON, opt-out with =0

--- a/src/context.js
+++ b/src/context.js
@@ -9,26 +9,37 @@ const REQUIRED_ARTIFACTS = [
   'constitutions/demerzel-mandate.md',
 ];
 
-function validateDemerzelPath() {
-  const resolved = path.resolve(REPO_PATH);
+function validateDemerzelPath(repoPath = REPO_PATH) {
+  const resolved = path.resolve(repoPath);
   if (!fs.existsSync(resolved)) {
-    console.error(`[demerzel-bot] Demerzel repo not found at: ${resolved}`);
-    console.error(`  Set DEMERZEL_REPO_PATH or clone Demerzel as a sibling directory.`);
-    process.exit(1);
+    return {
+      ok: false,
+      resolvedPath: resolved,
+      missingArtifacts: [],
+      message: `[demerzel-bot] Demerzel repo not found at: ${resolved}\n` +
+        '  Set DEMERZEL_REPO_PATH or clone Demerzel as a sibling directory.',
+    };
   }
   const missing = REQUIRED_ARTIFACTS.filter(
     (a) => !fs.existsSync(path.join(resolved, a))
   );
   if (missing.length > 0) {
-    console.error(`[demerzel-bot] Demerzel repo found at ${resolved} but missing required artifacts:`);
-    missing.forEach((a) => console.error(`  - ${a}`));
-    console.error(`  Ensure the Demerzel repo is up to date (git pull).`);
-    process.exit(1);
+    return {
+      ok: false,
+      resolvedPath: resolved,
+      missingArtifacts: missing,
+      message: `[demerzel-bot] Demerzel repo found at ${resolved} but missing required artifacts:\n` +
+        missing.map((a) => `  - ${a}`).join('\n') +
+        '\n  Ensure the Demerzel repo is up to date (git pull).',
+    };
   }
-  console.log(`[demerzel-bot] Demerzel repo validated at: ${resolved}`);
+  return {
+    ok: true,
+    resolvedPath: resolved,
+    missingArtifacts: [],
+    message: `[demerzel-bot] Demerzel repo validated at: ${resolved}`,
+  };
 }
-
-validateDemerzelPath();
 
 function readFile(relativePath) {
   try {
@@ -465,4 +476,13 @@ function getGovernanceTools() {
   ];
 }
 
-module.exports = { buildDemerzelSystemPrompt, buildSeldonSystemPrompt, buildGASystemPrompt, buildBSPrompt, getMusicTools, getGovernanceTools };
+module.exports = {
+  REQUIRED_ARTIFACTS,
+  validateDemerzelPath,
+  buildDemerzelSystemPrompt,
+  buildSeldonSystemPrompt,
+  buildGASystemPrompt,
+  buildBSPrompt,
+  getMusicTools,
+  getGovernanceTools,
+};


### PR DESCRIPTION
## What changed

- separated Demerzel artifact validation from process termination and prompt assembly
- kept startup fail-closed in `src/bot.js` with the existing actionable diagnostics
- added offline temporary-fixture tests for a valid repo, a missing repo, and each required artifact
- added `npm run test:context`

## Why

`src/context.js` previously called `process.exit(1)` while being imported, which made the startup safety boundary impossible to unit test without loading the bot runtime.

## Impact

Importing the context module is now side-effect free. Bot startup still exits with status 1 when governance artifacts are unavailable or incomplete. Prompt content and the Loaded-not-Enforced authority boundary are unchanged. Tests make no Discord, Anthropic, OpenAI, Ollama, or other service calls.

## Verification

- `npm run test:context` — 7/7 passed
- `node --check` — all 16 JavaScript files passed
- `git diff --check` — passed

Fixes #8