### PR TITLE
refactor(bot): extract persona routing policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node src/bot.js",
     "dev": "node --watch src/bot.js",
     "test:context": "node --test scripts/test-context.js",
+    "test:persona-router": "node --test scripts/test-persona-router.js",
     "test:voice": "node scripts/test-voice-pipeline.js"
   },
   "keywords": [

--- a/scripts/test-persona-router.js
+++ b/scripts/test-persona-router.js
@@ -1,0 +1,70 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { detectPersona } = require('../src/persona-router');
+
+function message(content, channelName) {
+  return {
+    content,
+    channel: channelName === undefined ? {} : { name: channelName },
+  };
+}
+
+const cases = [
+  {
+    name: 'DM with no routing signal uses the Demerzel fallback',
+    input: message('hello there'),
+    expected: 'demerzel',
+  },
+  {
+    name: 'academy channel selects Seldon',
+    input: message('hello', 'academy'),
+    expected: 'seldon',
+  },
+  {
+    name: 'research channel selects Seldon',
+    input: message('summarize the findings', 'research'),
+    expected: 'seldon',
+  },
+  {
+    name: 'governance channel selects Demerzel',
+    input: message('status update', 'governance'),
+    expected: 'demerzel',
+  },
+  {
+    name: 'explicit Seldon prefix selects Seldon',
+    input: message('Seldon: hello there', 'general'),
+    expected: 'seldon',
+  },
+  {
+    name: 'explicit Demerzel prefix selects Demerzel',
+    input: message('Demerzel: hello there', 'general'),
+    expected: 'demerzel',
+  },
+  {
+    name: 'guitar content selects the GA persona',
+    input: message('show me a Dorian guitar scale', 'general'),
+    expected: 'ga',
+  },
+  {
+    name: 'BS detector content selects the BS persona',
+    input: message('translate this BS', 'general'),
+    expected: 'bs',
+  },
+  {
+    name: 'ambiguous Seldon and governance signals preserve Seldon precedence',
+    input: message('Seldon, audit this constitution', 'governance'),
+    expected: 'seldon',
+  },
+  {
+    name: 'unmatched content uses the Demerzel fallback',
+    input: message('thanks for the update', 'general'),
+    expected: 'demerzel',
+  },
+];
+
+for (const example of cases) {
+  test(example.name, () => {
+    assert.equal(detectPersona(example.input), example.expected);
+  });
+}

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const { detectPersona } = require('./persona-router');
 const {
   validateDemerzelPath,
   buildDemerzelSystemPrompt,
@@ -79,55 +80,6 @@ function addToHistory(channelId, role, content) {
   if (history.length > MAX_HISTORY * 2) {
     history.splice(0, 2); // Remove oldest pair
   }
-}
-
-function detectPersona(message) {
-  const content = message.content.toLowerCase();
-  const channelName = message.channel.name || '';
-
-  // Explicit persona triggers
-  if (content.includes('seldon') || content.includes('teach') || content.includes('learn') ||
-      content.includes('course') || content.includes('lesson') || content.includes('academy') ||
-      channelName.includes('seldon') || channelName.includes('academy')) {
-    return 'seldon';
-  }
-
-  if (content.includes('demerzel') || content.includes('govern') || content.includes('constitution') ||
-      content.includes('policy') || content.includes('audit') || content.includes('conscience') ||
-      channelName.includes('demerzel') || channelName.includes('governance') || channelName.includes('dev-ops')) {
-    return 'demerzel';
-  }
-
-  // Research channel → Seldon
-  if (channelName.includes('research')) {
-    return 'seldon';
-  }
-
-  // BS detector / clarity channels
-  if (channelName.includes('bs-detector') || channelName.includes('clarity') || channelName.includes('bs') ||
-      content.includes('translate this bs') || content.includes('detect bs') ||
-      content.includes('generate bs') || content.includes('corporate speak') ||
-      content.includes('buzzword')) {
-    return 'bs';
-  }
-
-  // Music/guitar questions → GA musician persona
-  if (content.includes('guitar') || content.includes('chord') || content.includes('scale') ||
-      content.includes('tab') || content.includes('fretboard') || content.includes('improvise') ||
-      content.includes('progression') || content.includes('reharmonize') || content.includes('optic') ||
-      content.includes('practice') || content.includes('song') || content.includes('pentatonic') ||
-      content.includes('mode') || content.includes('dorian') || content.includes('mixolydian') ||
-      content.includes('voice leading') || content.includes('backing track') ||
-      channelName.includes('music') || channelName.includes('guitar')) {
-    return 'ga';
-  }
-
-  // General music theory → Seldon for teaching
-  if (content.includes('music') || content.includes('theory') || content.includes('lesson')) {
-    return 'seldon';
-  }
-
-  return 'demerzel';
 }
 
 async function generateResponse(persona, channelId, userMessage, currentChannel) {

--- a/src/persona-router.js
+++ b/src/persona-router.js
@@ -1,0 +1,45 @@
+function detectPersona(message) {
+  const content = message.content.toLowerCase();
+  const channelName = message.channel.name || '';
+
+  if (content.includes('seldon') || content.includes('teach') || content.includes('learn') ||
+      content.includes('course') || content.includes('lesson') || content.includes('academy') ||
+      channelName.includes('seldon') || channelName.includes('academy')) {
+    return 'seldon';
+  }
+
+  if (content.includes('demerzel') || content.includes('govern') || content.includes('constitution') ||
+      content.includes('policy') || content.includes('audit') || content.includes('conscience') ||
+      channelName.includes('demerzel') || channelName.includes('governance') || channelName.includes('dev-ops')) {
+    return 'demerzel';
+  }
+
+  if (channelName.includes('research')) {
+    return 'seldon';
+  }
+
+  if (channelName.includes('bs-detector') || channelName.includes('clarity') || channelName.includes('bs') ||
+      content.includes('translate this bs') || content.includes('detect bs') ||
+      content.includes('generate bs') || content.includes('corporate speak') ||
+      content.includes('buzzword')) {
+    return 'bs';
+  }
+
+  if (content.includes('guitar') || content.includes('chord') || content.includes('scale') ||
+      content.includes('tab') || content.includes('fretboard') || content.includes('improvise') ||
+      content.includes('progression') || content.includes('reharmonize') || content.includes('optic') ||
+      content.includes('practice') || content.includes('song') || content.includes('pentatonic') ||
+      content.includes('mode') || content.includes('dorian') || content.includes('mixolydian') ||
+      content.includes('voice leading') || content.includes('backing track') ||
+      channelName.includes('music') || channelName.includes('guitar')) {
+    return 'ga';
+  }
+
+  if (content.includes('music') || content.includes('theory') || content.includes('lesson')) {
+    return 'seldon';
+  }
+
+  return 'demerzel';
+}
+
+module.exports = { detectPersona };


### PR DESCRIPTION
## What changed

- Extracted `detectPersona(message)` into the side-effect-free `src/persona-router.js` module.
- Kept bot startup and message handling wired to the extracted policy.
- Added an offline characterization table covering DM fallback, named channels, explicit persona prefixes, content routing, ambiguous precedence, and default behavior.
- Added `npm run test:persona-router`.

## Why

Persona routing was embedded in `src/bot.js`, which also initializes Discord, providers, lock files, and runtime state. That made the policy impossible to characterize through a deterministic offline seam.

## Validation

- `npm run test:persona-router`: 10/10 passed.
- `npm run test:context`: 7/7 passed.
- `node --check src/persona-router.js` and `node --check src/bot.js`: passed.
- Independent audit: no remaining P0-P3 findings.

Closes #9